### PR TITLE
docs: Integrate ND__Post_Installation_Audit.md prompt

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,30 +23,26 @@ Extract the ZIP and add the `noderr` folder to your project:
 That's it! You now have the Noderr framework in your project.
 
 ### 3. Run Install and Reconcile
-
 Give your AI assistant this prompt:
 ```
 ND__Install_And_Reconcile.md
 ```
 
-This will:
-1. Analyze what was actually built vs. your original plans
-2. Update all Noderr files to match reality
-3. **Pause for your review** of the updated project files
-4. Create specifications for all components (after approval)
-5. Configure your development environment
-6. Set up the tracking system
+### 4. Run System Audit
+Verify everything is ready:
+```
+ND__Post_Installation_Audit.md
+```
+This ensures 100% architectural completeness and system readiness.
 
-### 4. Review and Approve
-
+### 5. Review and Approve
 When the AI pauses:
-- Review `noderr/noderr_project.md` - Does it accurately reflect what was built?
-- Review `noderr/noderr_architecture.md` - Does the diagram match your system?
-- Approve to continue with specification generation
+- Review audit report for any issues
+- Address any critical gaps identified
+- Confirm development readiness percentage
 
 ## Post-Installation
-
-Once installation is complete, start development:
+Once audit shows 100% readiness:
 ```
 ND__Start_Work_Session.md
 ```

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ AI: "This requires changing:
 Unlike traditional tools, Noderr is installed AFTER you build your initial prototype. This ensures it documents what actually exists, not just what was planned.
 
 ### Quick Install
-
 1. **Prepare your vision** (blueprint, project overview, architecture)
 2. **Build initial prototype** with AI based on those plans
 3. **Download & add Noderr** - [Get noderr-starter.zip](https://github.com/kaithoughtarchitect/noderr/releases/latest/download/noderr-starter.zip)
 4. **Run Install prompt** - `ND__Install_And_Reconcile.md`
+5. **Run System Audit** - `ND__Post_Installation_Audit.md`
 
 See [Getting Started](./docs/getting-started.md) for detailed instructions.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,23 +135,21 @@ your-project/
 ```
 
 ### Step 4: Run Install and Reconcile
-
 Give your AI this command:
 > **`ND__Install_And_Reconcile.md`**
 
-This critical step will:
-1. **Analyze** what was actually built vs. planned
-2. **Update** the project and architecture files to match reality
-3. **PAUSE** for your review and approval
-4. **Create** detailed specs for every component
-5. **Configure** your development environment
-6. **Set up** the tracking system
+### Step 5: Verify System Readiness
+After installation, run a comprehensive audit:
+> **`ND__Post_Installation_Audit.md`**
 
-**Important:** The AI will pause after updating the project files. Review them carefully before approving continuation.
+This will:
+- Verify all Noderr components are working
+- Identify missing architectural NodeIDs
+- Auto-create specifications for gaps
+- Provide development readiness report
 
-### Step 5: Begin Systematic Development
-
-Once installation is complete:
+### Step 6: Begin Systematic Development
+Once audit shows 100% readiness:
 > **`ND__Start_Work_Session.md`**
 
 You're now ready to use the Noderr loop for all future development!

--- a/docs/prompts-guide.md
+++ b/docs/prompts-guide.md
@@ -28,6 +28,7 @@ These are the commands you'll use to manage the project's lifecycle.
 |:-------|:--------|:------------|
 | `ND__Strategic_Blueprint_Designer.md` | Create strategic foundation | Before building, to establish rich context |
 | `ND__Install_And_Reconcile.md` | Install Noderr after initial build | Once, after extracting ZIP |
+| `ND__Post_Installation_Audit.md` | **NEW** - Verify system integrity and complete architecture | Immediately after Install_And_Reconcile |
 
 ### Daily Operations
 


### PR DESCRIPTION
Integrates the new `ND__Post_Installation_Audit.md` prompt into the documentation.

This commit updates the following files:
- `docs/getting-started.md`: Adds the audit step to the initial setup process.
- `docs/prompts-guide.md`: Adds the new prompt to the prompts guide.
- `INSTALL.md`: Adds the audit step to the installation instructions.
- `README.md`: Adds the audit step to the quick install guide.

These changes ensure that the new audit prompt is properly documented and integrated into the user workflow.