### PR TITLE
docs: update noderr.starter.zip download link to v1.9.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ Before installing Noderr:
 
 ### 1. Download Noderr
 
-Download the latest release: [noderr-starter.zip](https://github.com/kaithoughtarchitect/noderr/releases/download/v1.9.0/noderr.starter.zip)
+Download the latest release: [noderr-starter.zip](https://github.com/kaithoughtarchitect/noderr/releases/download/v1.9.1/noderr.starter.zip)
 
 ### 2. Add to Your Project
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Unlike traditional tools, Noderr is installed AFTER you build your initial proto
 ### Quick Install
 1. **Prepare your vision** (blueprint, project overview, architecture)
 2. **Build initial prototype** with AI based on those plans
-3. **Download & add Noderr** - [Get noderr-starter.zip](https://github.com/kaithoughtarchitect/noderr/releases/download/v1.9.0/noderr.starter.zip)
+3. **Download & add Noderr** - [Get noderr-starter.zip](https://github.com/kaithoughtarchitect/noderr/releases/download/v1.9.1/noderr.starter.zip)
 4. **Run Install prompt** - `noderr/prompts/ND__Install_And_Reconcile.md`
 5. **Run System Audit** - `noderr/prompts/ND__Post_Installation_Audit.md`
 

--- a/docs/noderr_getting_started.md
+++ b/docs/noderr_getting_started.md
@@ -42,7 +42,7 @@ This approach ensures Noderr documents what you ACTUALLY built, not just what yo
 
 ### Download Noderr
 
-1. **Download the latest release:** [noderr-starter.zip](https://github.com/kaithoughtarchitect/noderr/releases/download/v1.9.0/noderr.starter.zip)
+1. **Download the latest release:** [noderr.starter.zip](https://github.com/kaithoughtarchitect/noderr/releases/download/v1.9.1/noderr.starter.zip)
 2. **Keep the ZIP file handy** - you'll extract it AFTER your initial build
 
 The ZIP contains:
@@ -124,7 +124,7 @@ NOW extract the Noderr ZIP into your project root:
 
 ```bash
 # Extract the ZIP
-unzip noderr-starter.zip -d your-project/
+unzip noderr.starter.zip -d your-project/
 
 # You should see:
 your-project/


### PR DESCRIPTION
Updated the download link for `noderr.starter.zip` to point to the new v1.9.1 release.

The following files were updated:
- INSTALL.md
- README.md
- docs/noderr_getting_started.md

Also corrected a typo in `docs/noderr_getting_started.md` where the `unzip` command was using `noderr-starter.zip` instead of `noderr.starter.zip`.